### PR TITLE
Only draw the overlay images and crosshair when the user has path of …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ config = "0.13.3"
 serde = "1.0.151"
 gilrs = {version ="0.10.1", default-features = false, features = ["xinput"]}
 rdev = "0.5.2"
+active-win-pos-rs = "0.7.1"
 
 # egui
 egui = "0.19.0"

--- a/src/overlay/game_overlay.rs
+++ b/src/overlay/game_overlay.rs
@@ -103,8 +103,27 @@ struct GameOverlay {
     controller_check_timer: Instant,
 }
 
+fn is_poe_active() -> bool {
+    let active_window = active_win_pos_rs::get_active_window();
+        match active_window {
+            Ok(active_window) => {
+                if active_window.title.to_lowercase() == "Path of Exile".to_lowercase() {
+                    true
+                } else {
+                    false
+                }
+            },
+            Err(_) => false,
+        }
+}
+
 impl GameOverlay {
     fn place_overlay_image(&self, ctx: &Context, image: &RetainedImage, position: Pos2, id_source: &str) {
+        // Don't draw on the user's screen if they don't need the overlay
+        if !is_poe_active() {
+            return;
+        }
+
         egui_backend::egui::Area::new(id_source)
                                     .movable(false)
                                     .fixed_pos(position)
@@ -169,6 +188,11 @@ impl GameOverlay {
     }
 
     fn paint_crosshair (&self, ctx: &Context) {
+        // Don't draw on the user's screen if they don't need the overlay
+        if !is_poe_active() {
+            return;
+        }
+
         let crosshair_radius = 5.0;
         // offset radius*2.0 because the paint area is radius * 4 across
         let crosshair_position = Pos2 { x: (self.overlay_settings.screen_width() / 2.0) - self.controller_settings.character_x_offset_px() - crosshair_radius*2.0, 

--- a/src/overlay/game_overlay.rs
+++ b/src/overlay/game_overlay.rs
@@ -103,27 +103,22 @@ struct GameOverlay {
     controller_check_timer: Instant,
 }
 
-fn is_poe_active() -> bool {
-    let active_window = active_win_pos_rs::get_active_window();
-        match active_window {
-            Ok(active_window) => {
-                if active_window.title.to_lowercase() == "Path of Exile".to_lowercase() {
-                    true
-                } else {
-                    false
-                }
-            },
-            Err(_) => false,
-        }
-}
-
 impl GameOverlay {
-    fn place_overlay_image(&self, ctx: &Context, image: &RetainedImage, position: Pos2, id_source: &str) {
-        // Don't draw on the user's screen if they don't need the overlay
-        if !is_poe_active() {
-            return;
-        }
+    fn is_poe_active() -> bool {
+        let active_window = active_win_pos_rs::get_active_window();
+            match active_window {
+                Ok(active_window) => {
+                    if active_window.title.to_lowercase() == "Path of Exile".to_lowercase() {
+                        true
+                    } else {
+                        false
+                    }
+                },
+                Err(_) => false,
+            }
+    }
 
+    fn place_overlay_image(&self, ctx: &Context, image: &RetainedImage, position: Pos2, id_source: &str) {
         egui_backend::egui::Area::new(id_source)
                                     .movable(false)
                                     .fixed_pos(position)
@@ -188,11 +183,6 @@ impl GameOverlay {
     }
 
     fn paint_crosshair (&self, ctx: &Context) {
-        // Don't draw on the user's screen if they don't need the overlay
-        if !is_poe_active() {
-            return;
-        }
-
         let crosshair_radius = 5.0;
         // offset radius*2.0 because the paint area is radius * 4 across
         let crosshair_position = Pos2 { x: (self.overlay_settings.screen_width() / 2.0) - self.controller_settings.character_x_offset_px() - crosshair_radius*2.0, 
@@ -339,13 +329,13 @@ impl UserApp<egui_window_glfw_passthrough::GlfwWindow, WgpuBackend> for GameOver
         self.draw_remote(egui_context);
 
         if self.game_input_started {
-            if self.overlay_settings.show_buttons() {
+            if self.overlay_settings.show_buttons() && Self::is_poe_active() {
                 self.place_flask_overlay_images(egui_context, &self.overlay_images);
                 self.place_face_overlay_images(egui_context, &self.overlay_images);
                 self.place_mouse_button_overlay_images(egui_context, &self.overlay_images);
             }
 
-            if self.overlay_settings.show_crosshair() {
+            if self.overlay_settings.show_crosshair() && Self::is_poe_active() {
                 self.paint_crosshair(egui_context);
             }
 


### PR DESCRIPTION
…exile focused.

This is a relatively small change that might need to be configurable? Either way, it works on my machine, but I would love a windows client to give it a run.

edit:

This also pulls in a dependency that should make supporting windowed mode much easier.