### PR TITLE
Replaces most instances of string matching with their concrete types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT"
 [dependencies]
 config = {version = "0.15.19"}
 serde = {version = "1.0.228", features = ["derive"]}
-gilrs = {version ="0.11.0", default-features = false, features = ["xinput"]}
-rdev = "0.5.3"
+gilrs = {version ="0.11.0", default-features = false, features = ["serde-serialize", "xinput"]}
+rdev = {version = "0.5.3", features = ["serialize"]}
 active-win-pos-rs = "0.9.1"
 native-dialog = "0.9.4"
 

--- a/settings.toml
+++ b/settings.toml
@@ -4,11 +4,11 @@ aimable_buttons = ["bumper_right"]
 
 # Sets action distance from character when pushed while moving or move-aiming. 
 # Ideal for setting movement skill distances, totem drop distances, etc
-# Must be close/mid/far; Aimable buttons without this will snap to "walk" distance.
+# Must be one of: "Close", "Mid", "Far"; Aimable buttons without this will snap to "walk" distance.
 # When not moving or move-aiming, all skills target current mouse position without snapping.
 # May get weird if holding several buttons.
 # Bumpers, triggers and abxy only!
-action_distances = {face_left = "far", face_down = "mid"}
+action_distances = {face_left = "Far", face_down = "Mid"}
 
 # You must bind your left-click ability in PoE to movement.
 # You must also let the game use default ability mappings for QWERT

--- a/src/controller/action_handler.rs
+++ b/src/controller/action_handler.rs
@@ -1,7 +1,7 @@
 use rdev::{simulate, Button, EventType, Key, SimulateError};
 use std::{thread, time, collections::HashMap};
 
-use crate::settings::{alert_and_exit_on_invalid_settings};
+use crate::settings::ButtonOrKey;
 
 #[derive(PartialEq)]
 pub enum ActionType {
@@ -10,9 +10,7 @@ pub enum ActionType {
 }
 
 pub struct ActionHandler {
-    left_mouse_held: bool,
-    middle_mouse_held: bool,
-    right_mouse_held: bool,
+    mouse_button_down: HashMap<Button, bool>,
     held_keys: HashMap<Key, String>,
     holding_left_click_for_action: bool,
 }
@@ -20,9 +18,10 @@ pub struct ActionHandler {
 impl Default for ActionHandler {
     fn default() -> Self {
         ActionHandler {
-            left_mouse_held: false,
-            middle_mouse_held: false,
-            right_mouse_held: false,
+            mouse_button_down: HashMap::from([
+                (Button::Left, false),
+                (Button::Middle, false),
+                (Button::Right, false),]),
             held_keys: HashMap::<Key, String>::with_capacity(20),
             holding_left_click_for_action: false,
         }
@@ -30,31 +29,12 @@ impl Default for ActionHandler {
 }
 
 impl ActionHandler {
-    pub fn handle_action(&mut self, action_type: ActionType, action: String) {
-        let action_lower = action.to_lowercase();
-        let action_str = action_lower.as_str();
-        match action_str {
-            // Check for known "special" cases first.
-            "altleftclick" => { 
-                self.handle_action_with_modifier_key(action_type, "leftclick".to_owned(), "alt".to_owned(), 20, 10);
-            },
-            // Not a special case, fall through
-            _ => { 
-                if let Some(mouse_button) = self.match_mouse_str_to_button(action_str) {
-                    // "LeftClick" => {self.handle_mouse_action(self.match_mouse_str_to_button(action.as_str()), action_type);},
-                    // "MiddleClick" => {self.handle_mouse_action(self.match_mouse_str_to_button(action.as_str()), action_type);},
-                    // "RightClick" => {self.handle_mouse_action(self.match_mouse_str_to_button(action.as_str()), action_type);},
-                    self.handle_mouse_action(mouse_button, action_type);
-                } else if let Some(key_button) = self.match_key_str_to_key(action_str) {
-                    // self.handle_keypress_action(self.match_key_str_to_key(action.to_lowercase().as_str()), action_type, action);
-                    self.handle_keypress_action(key_button, action_type, action);
-                } else {
-                    // TODO: We should probably check this on config load, but keeping it here for now because if bindable keys / actions changes, it'll happen here.
-                    alert_and_exit_on_invalid_settings(&format!("Invalid action configured in settings: {:?}", action_str));
-                    panic!("Invalid action configured in settings: {:?}", action_str); 
-                }
-                
-            }
+    pub fn handle_action(&mut self, action_type: ActionType, action: &ButtonOrKey) {
+        match action {
+            ButtonOrKey::ButtonKeyCombo(mouse_button, key) => self.handle_action_with_mouse_and_key(key, mouse_button, action_type, 20, 10),
+            ButtonOrKey::Button(mouse_button) => self.handle_mouse_action(mouse_button, action_type),
+            ButtonOrKey::Key(key) => self.handle_keypress_action(key, action_type),
+            ButtonOrKey::Empty => (),
         }
     }
 
@@ -62,205 +42,85 @@ impl ActionHandler {
         self.holding_left_click_for_action
     }
 
-    fn match_mouse_str_to_button(&self, mouse_str: &str) -> Option<Button> {
-        match mouse_str {
-            "leftclick" => {Some(Button::Left)},
-            "middleclick" => {Some(Button::Middle)},
-            "rightclick" => {Some(Button::Right)},
-            &_ => { None }
-        }
-    }
-
-    fn match_key_str_to_key(&self, key_str: &str) -> Option<Key> {
-        match key_str {            
-            "f1" => {Some(Key::F1)},
-            "f2" => {Some(Key::F2)},
-            "f3" => {Some(Key::F3)},
-            "f4" => {Some(Key::F4)},
-            "f5" => {Some(Key::F5)},
-            "f6" => {Some(Key::F6)},
-            "f7" => {Some(Key::F7)},
-            "f8" => {Some(Key::F8)},
-            "f9" => {Some(Key::F9)},
-            "f10" => {Some(Key::F10)},
-            "f11" => {Some(Key::F11)},
-            "f12" => {Some(Key::F12)},
-            "a" => {Some(Key::KeyA)},
-            "b" => {Some(Key::KeyB)},
-            "c" => {Some(Key::KeyC)},
-            "d" => {Some(Key::KeyD)},
-            "e" => {Some(Key::KeyE)},
-            "f" => {Some(Key::KeyF)},
-            "g" => {Some(Key::KeyG)},
-            "h" => {Some(Key::KeyH)},
-            "i" => {Some(Key::KeyI)},
-            "j" => {Some(Key::KeyJ)},
-            "k" => {Some(Key::KeyK)},
-            "l" => {Some(Key::KeyL)},
-            "m" => {Some(Key::KeyM)},
-            "n" => {Some(Key::KeyN)},
-            "o" => {Some(Key::KeyO)},
-            "p" => {Some(Key::KeyP)},
-            "q" => {Some(Key::KeyQ)},
-            "r" => {Some(Key::KeyR)},
-            "s" => {Some(Key::KeyS)},
-            "t" => {Some(Key::KeyT)},
-            "u" => {Some(Key::KeyU)},
-            "v" => {Some(Key::KeyV)},
-            "w" => {Some(Key::KeyW)},
-            "x" => {Some(Key::KeyX)},
-            "y" => {Some(Key::KeyY)},
-            "z" => {Some(Key::KeyZ)},
-            "0" => {Some(Key::Num0)},
-            "1" => {Some(Key::Num1)},
-            "2" => {Some(Key::Num2)},
-            "3" => {Some(Key::Num3)},
-            "4" => {Some(Key::Num4)},
-            "5" => {Some(Key::Num5)},
-            "6" => {Some(Key::Num6)},
-            "7" => {Some(Key::Num7)},
-            "8" => {Some(Key::Num8)},
-            "9" => {Some(Key::Num9)},
-            "`" => {Some(Key::BackQuote)},
-            "[" => {Some(Key::LeftBracket)},
-            "]" => {Some(Key::RightBracket)},
-            ";" => {Some(Key::SemiColon)},
-            "/" => {Some(Key::Slash)},
-            "," => {Some(Key::Comma)},
-            "=" => {Some(Key::Equal)},
-            "escape" => {Some(Key::Escape)},
-            "space" => {Some(Key::Space)},
-            "tab" => {Some(Key::Tab)},
-            "backspace" => {Some(Key::Backspace)},
-            "delete" => {Some(Key::Delete)},
-            "uparrow" => {Some(Key::UpArrow)},
-            "downarrow" => {Some(Key::DownArrow)},
-            "leftarrow" => {Some(Key::LeftArrow)},
-            "rightarrow" => {Some(Key::RightArrow)},
-            "alt" => {Some(Key::Alt)},
-            "shift" => {Some(Key::ShiftLeft)},
-            "control" => {Some(Key::ControlLeft)},
-            &_ => { None }
-        }
-    }
-
     pub fn move_mouse(&self, x: f64, y: f64) {
         rdev_send_event(&EventType::MouseMove { x, y });
     }
 
-    fn handle_mouse_action(&mut self, mouse_button: Button, action: ActionType) {
+    fn handle_mouse_action(&mut self, mouse_button: &Button, action_type: ActionType) {
         // Action handler tracks held mouse button state to avoid safely spamming events
-        match mouse_button {
-            Button::Left => {
-                if action == ActionType::Press && !self.left_mouse_held {
-                    self.left_mouse_held = true;
-                    rdev_send_event(&EventType::ButtonPress(mouse_button))
-                } else if action == ActionType::Release && self.left_mouse_held {
-                    self.left_mouse_held = false;
-                    rdev_send_event(&EventType::ButtonRelease(mouse_button))
-                }
+        match (action_type, self.mouse_button_down.get(&mouse_button)) {
+            (ActionType::Press, Some(false)) => {
+                self.mouse_button_down.insert(*mouse_button, true);
+                rdev_send_event(&EventType::ButtonPress(*mouse_button))
             },
-            Button::Middle => {
-                if action == ActionType::Press && !self.middle_mouse_held {
-                    self.middle_mouse_held = true;
-                    rdev_send_event(&EventType::ButtonPress(mouse_button))
-                } else if action == ActionType::Release && self.middle_mouse_held {
-                    self.middle_mouse_held = false;
-                    rdev_send_event(&EventType::ButtonRelease(mouse_button))
-                }
+            (ActionType::Release, Some(true)) => {
+                self.mouse_button_down.insert(*mouse_button, false);
+                rdev_send_event(&EventType::ButtonRelease(*mouse_button))
             },
-            Button::Right => {
-                if action == ActionType::Press && !self.right_mouse_held {
-                    self.right_mouse_held = true;
-                    rdev_send_event(&EventType::ButtonPress(mouse_button))
-                } else if action == ActionType::Release && self.right_mouse_held {
-                    self.right_mouse_held = false;
-                    rdev_send_event(&EventType::ButtonRelease(mouse_button))
-                }
-            },
-            _ => ()
+            _ => (),
         }
     }
 
-    fn handle_keypress_action(&mut self, keypress: Key, action: ActionType, action_string: String) {
+    fn handle_keypress_action(&mut self, keypress: &Key, action: ActionType) {
         if action == ActionType::Press {
             if !self.held_keys.contains_key(&keypress) {
-                rdev_send_event(&EventType::KeyPress(keypress));
-                self.held_keys.insert(keypress, action_string);
+                rdev_send_event(&EventType::KeyPress(*keypress));
+                self.held_keys.insert(*keypress, format!("{:#?}", keypress));
             }
         } else if action == ActionType::Release {
             if self.held_keys.contains_key(&keypress) {
-                rdev_send_event(&EventType::KeyRelease(keypress));
-                self.held_keys.remove(&keypress);
+                rdev_send_event(&EventType::KeyRelease(*keypress));
+                self.held_keys.remove(keypress);
             }
         }
     }
 
-    fn handle_action_with_modifier_key(&mut self, action_type: ActionType, action: String, modifier: String, delay_ms_before: u64, delay_ms_after: u64) {
-        // We can trust this lookup so long as we only call this function with known inputs. 
-        // If inputs are user-specified, we must refactor to check them.
-        let modifier_key = self.match_key_str_to_key(&modifier).unwrap();
+    fn handle_action_with_mouse_and_key(&mut self, modifier_key: &Key, mouse_button: &Button, action_type: ActionType, delay_ms_before: u64, delay_ms_after: u64) {
         let modifier_already_held = self.held_keys.contains_key(&modifier_key);
-        let mut action_string = modifier.to_owned();
-        action_string.push_str(action.as_str());
-
-        if action_type == ActionType::Press {
-            if !modifier_already_held {
-                self.handle_keypress_action(modifier_key, ActionType::Press, action_string.clone());
-                thread::sleep(time::Duration::from_millis(delay_ms_before));
-            }
-
-            if let Some(mouse_button) = self.match_mouse_str_to_button(&action) {
-                // println!("pushing mouse action {:?}", &action);
+        match action_type {
+            ActionType::Press => {
+                if !modifier_already_held {
+                    self.handle_keypress_action(modifier_key, ActionType::Press);
+                    thread::sleep(time::Duration::from_millis(delay_ms_before));
+                }
                 self.handle_mouse_action(mouse_button, ActionType::Press);
                 self.holding_left_click_for_action = true;
-            } else if let Some(key_button) = self.match_key_str_to_key(&action) {
-                // This will not press again if another controller button is already holding this key
-                self.handle_keypress_action(key_button, ActionType::Press, action.clone());
-            }
-
-            if !modifier_already_held {
-                thread::sleep(time::Duration::from_millis(delay_ms_after));
-                self.handle_keypress_action(modifier_key, ActionType::Release, action_string);
-            }
-        } 
-        else if action_type == ActionType::Release {
-            if let Some(mouse_button) = self.match_mouse_str_to_button(&action) {
+                if !modifier_already_held {
+                    thread::sleep(time::Duration::from_millis(delay_ms_after));
+                    self.handle_keypress_action(modifier_key, ActionType::Release);
+                }
+            },
+            ActionType::Release => {
                 self.handle_mouse_action(mouse_button, ActionType::Release);
                 self.holding_left_click_for_action = false;
-            } else if let Some(key_button) = self.match_key_str_to_key(&action) {
                 // This will unpress even if another controller button is already holding this key
-                self.handle_keypress_action(key_button, ActionType::Release, action.clone());
-            }
-        } 
+                self.handle_keypress_action(modifier_key, ActionType::Release);
+            },
+        }
     }
 
     pub fn is_ability_key_held(&self) -> bool {
         let mut is_holding = false;
-        if self.middle_mouse_held || self.right_mouse_held {
+        if *self.mouse_button_down.get(&Button::Middle).unwrap() || *self.mouse_button_down.get(&Button::Right).unwrap() {
             is_holding = true;
-        } 
+        }
         for key in self.held_keys.keys() {
             match key {
-                Key::KeyQ => {is_holding = true;},
-                Key::KeyW => {is_holding = true;},
-                Key::KeyE => {is_holding = true;},
-                Key::KeyR => {is_holding = true;},
-                Key::KeyT => {is_holding = true;},
+                Key::KeyQ | Key::KeyW | Key::KeyE | Key::KeyR | Key::KeyT => is_holding = true,
                 _ => (),
             }
         }
         is_holding
     }
-    pub fn get_held_ability_actions(&self) -> Vec<String> {
-        let mut held_ability_actions = Vec::<String>::new();
-        if self.middle_mouse_held {held_ability_actions.push("MiddleClick".to_owned());}
-        if self.right_mouse_held {held_ability_actions.push("RightClick".to_owned());}
-        if self.held_keys.contains_key(&Key::KeyQ) {held_ability_actions.push("q".to_owned());}
-        if self.held_keys.contains_key(&Key::KeyW) {held_ability_actions.push("w".to_owned());}
-        if self.held_keys.contains_key(&Key::KeyE) {held_ability_actions.push("e".to_owned());}
-        if self.held_keys.contains_key(&Key::KeyR) {held_ability_actions.push("r".to_owned());}
-        if self.held_keys.contains_key(&Key::KeyT) {held_ability_actions.push("t".to_owned());}
+    pub fn get_held_ability_actions(&self) -> Vec<ButtonOrKey> {
+        let mut held_ability_actions = Vec::<ButtonOrKey>::new();
+        if *self.mouse_button_down.get(&Button::Middle).unwrap() {held_ability_actions.push(ButtonOrKey::Button(Button::Middle));}
+        if *self.mouse_button_down.get(&Button::Right).unwrap() {held_ability_actions.push(ButtonOrKey::Button(Button::Right));}
+        if self.held_keys.contains_key(&Key::KeyQ) {held_ability_actions.push(ButtonOrKey::Key(Key::KeyQ));}
+        if self.held_keys.contains_key(&Key::KeyW) {held_ability_actions.push(ButtonOrKey::Key(Key::KeyW));}
+        if self.held_keys.contains_key(&Key::KeyE) {held_ability_actions.push(ButtonOrKey::Key(Key::KeyE));}
+        if self.held_keys.contains_key(&Key::KeyR) {held_ability_actions.push(ButtonOrKey::Key(Key::KeyR));}
+        if self.held_keys.contains_key(&Key::KeyT) {held_ability_actions.push(ButtonOrKey::Key(Key::KeyT));}
         held_ability_actions
     }
 }

--- a/src/controller/action_manager.rs
+++ b/src/controller/action_manager.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
 use crate::game_window_tracker::GameWindowTracker;
-use crate::settings:: ApplicationSettings;
+use crate::settings:: {ApplicationSettings, ButtonOrKey};
 
 use super::input::{ControllerButton, AnalogStick};
 use super::action_handler::{ActionHandler, ActionType};
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize)]
 pub enum ActionDistance {
     Close,
     Mid,
@@ -15,7 +15,7 @@ pub enum ActionDistance {
 }
 
 struct PlannedAction {
-    name: String,
+    name: gilrs::Button,
     just_pressed: bool,
     aimable: bool,
     distance: ActionDistance,
@@ -54,13 +54,13 @@ impl ActionManager {
         }
     }
 
-    pub fn process_input_buttons(&mut self, named_controller_buttons: HashMap<String, &mut ControllerButton>) {
+    pub fn process_input_buttons(&mut self, named_controller_buttons: HashMap<gilrs::Button, &mut ControllerButton>) {
         for (action_name, button) in named_controller_buttons {
             if button.just_pressed {
                 println!("Just pressed {:?} ", action_name);
                 let can_be_aimed = self.settings.aimable_buttons().contains(&action_name);
-                let action_distance = self.get_ability_action_distance(&action_name);
-                self.planned_actions.push(PlannedAction {name: action_name.clone(), 
+                let action_distance = self.get_ability_action_distance(action_name);
+                self.planned_actions.push(PlannedAction {name: action_name,
                                                         just_pressed: true, 
                                                         aimable: can_be_aimed,
                                                         distance: action_distance,
@@ -69,7 +69,7 @@ impl ActionManager {
             }
             if button.just_unpressed {
                 println!("Just unpressed {:?} ", &action_name);
-                self.planned_actions.push(PlannedAction {name: action_name.clone(), 
+                self.planned_actions.push(PlannedAction {name: action_name,
                                                         just_pressed: false, 
                                                         aimable: false, // Don't need this for unpress
                                                         distance: ActionDistance::None, // Don't need this for unpress
@@ -104,29 +104,30 @@ impl ActionManager {
 
         // Execute planned actions
         while let Some(planned_action) = self.planned_actions.pop() {
-            let key_name = self.settings.button_mapping_settings().get(&planned_action.name).unwrap().to_string();
-            if key_name == "" {continue} // Empty string is how we set keymaps to not taking any action.
-            // println!("{key_name}");
-            if planned_action.just_pressed {
-                if planned_action.aimable {
-                    if self.holding_walk && self.holding_aim {
-                        let (new_x, new_y) = self.get_radial_location(self.get_attack_circle_radius(planned_action.distance), self.aiming_angle);
-                        self.safe_move_mouse(new_x as f64, new_y as f64);
-                        set_cursor = true;
-                    } else if self.holding_walk && !self.holding_aim {
+            if let Some(key_name) = self.settings.button_mapping_settings().get(&planned_action.name) {
+                if *key_name == ButtonOrKey::Empty {continue;} // Empty string is how we set keymaps to not taking any action.
+                // println!("{key_name}");
+                if planned_action.just_pressed {
+                    if planned_action.aimable {
+                        if self.holding_walk && self.holding_aim {
+                            let (new_x, new_y) = self.get_radial_location(self.get_attack_circle_radius(planned_action.distance), self.aiming_angle);
+                            self.safe_move_mouse(new_x as f64, new_y as f64);
+                            set_cursor = true;
+                        } else if self.holding_walk && !self.holding_aim {
+                            let (new_x, new_y) = self.get_radial_location(self.get_attack_circle_radius(planned_action.distance), self.walking_angle);
+                            self.safe_move_mouse(new_x as f64, new_y as f64);
+                            set_cursor = true;
+                        }
+                        // todo probably inject a delay for the two above
+                    } else if planned_action.distance != ActionDistance::None && self.holding_walk {
                         let (new_x, new_y) = self.get_radial_location(self.get_attack_circle_radius(planned_action.distance), self.walking_angle);
                         self.safe_move_mouse(new_x as f64, new_y as f64);
                         set_cursor = true;
                     }
-                    // todo probably inject a delay for the two above
-                } else if planned_action.distance != ActionDistance::None && self.holding_walk {
-                        let (new_x, new_y) = self.get_radial_location(self.get_attack_circle_radius(planned_action.distance), self.walking_angle);
-                        self.safe_move_mouse(new_x as f64, new_y as f64);
-                        set_cursor = true;
+                    self.action_handler.handle_action(ActionType::Press, key_name);
+                } else {
+                    self.action_handler.handle_action(ActionType::Release, key_name);
                 }
-                self.action_handler.handle_action(ActionType::Press, key_name);
-            } else {
-                self.action_handler.handle_action(ActionType::Release, key_name);
             }
         }
 
@@ -138,7 +139,7 @@ impl ActionManager {
         
 
         if self.holding_ability && self.holding_walk {
-            let held_ability_actions: Vec<String> = self.action_handler.get_held_ability_actions()
+            let held_ability_actions: Vec<gilrs::Button> = self.action_handler.get_held_ability_actions()
                                                                         .iter()
                                                                         .map(|key| self.settings.ability_mapping_settings().get(key).unwrap().to_owned())
                                                                         .collect();
@@ -154,9 +155,9 @@ impl ActionManager {
 
             // Of the abilities with an action distance, check for the farthest distance.
             let held_abilities_with_action_distance_set = held_ability_actions.into_iter()
-                                                                                    .filter(|action| self.get_ability_action_distance(action) != ActionDistance::None);
+                                                                                    .filter(|action| self.get_ability_action_distance(*action) != ActionDistance::None);
             let mut chosen_distance =  0.0;
-            for (_action, distance) in held_abilities_with_action_distance_set.map(|action| (action.to_owned(), self.get_attack_circle_radius(self.get_ability_action_distance(&action)))) {
+            for (_action, distance) in held_abilities_with_action_distance_set.map(|action| (action, self.get_attack_circle_radius(self.get_ability_action_distance(action)))) {
                 if distance > chosen_distance {
                     chosen_distance = distance;
                 }
@@ -190,9 +191,9 @@ impl ActionManager {
             self.safe_move_mouse(new_x as f64, new_y as f64);
         }
         if self.holding_walk {
-            self.action_handler.handle_action(ActionType::Press, "leftclick".to_string());
+            self.action_handler.handle_action(ActionType::Press, &ButtonOrKey::Button(rdev::Button::Left));
         } else if !self.action_handler.holding_left_click_for_action() {
-            self.action_handler.handle_action(ActionType::Release, "leftclick".to_string());
+            self.action_handler.handle_action(ActionType::Release, &ButtonOrKey::Button(rdev::Button::Left));
         }
   
     }
@@ -262,19 +263,12 @@ impl ActionManager {
         }
     }
 
-    fn get_ability_action_distance(&self, name: &String) -> ActionDistance {
-        if self.settings.action_distances().contains_key(name) {
-            // println!("herp {:?}", name);
-            match self.settings.action_distances().get(name).unwrap().as_str() {
-                "close" => {ActionDistance::Close},
-                "mid" => {ActionDistance::Mid},
-                "far" => {ActionDistance::Far},
-                _ => {ActionDistance::None}
-            }
-        } else {
-            // println!("derp {:?}", name);
-            ActionDistance::None}
-    } 
+    fn get_ability_action_distance(&self, button: gilrs::Button) -> ActionDistance {
+        match self.settings.action_distances().get(&button) {
+            Some(distance) => *distance,
+            None => ActionDistance::None,
+        }
+    }
 }
 
 

--- a/src/controller/input.rs
+++ b/src/controller/input.rs
@@ -133,27 +133,24 @@ pub struct ControllerState {
 }
 
 impl ControllerState {
-    pub fn get_all_buttons(&mut self) -> HashMap<String, &mut ControllerButton> {
-        let mut buttons = HashMap::new();
-
-        buttons.insert("dpad_up".to_string(), &mut self.dpad_up);
-        buttons.insert("dpad_down".to_string(), &mut self.dpad_down);
-        buttons.insert("dpad_left".to_string(), &mut self.dpad_left);
-        buttons.insert("dpad_right".to_string(), &mut self.dpad_right);
-        buttons.insert("start".to_string(), &mut self.start);
-        buttons.insert("back".to_string(), &mut self.back);
-        buttons.insert("face_up".to_string(), &mut self.y);
-        buttons.insert("face_down".to_string(), &mut self.a);
-        buttons.insert("face_right".to_string(), &mut self.b);
-        buttons.insert("face_left".to_string(), &mut self.x);
-        buttons.insert("bumper_left".to_string(), &mut self.bumper_left);
-        buttons.insert("trigger_left".to_string(), &mut self.trigger_left.button);
-        buttons.insert("bumper_right".to_string(), &mut self.bumper_right);
-        buttons.insert("trigger_right".to_string(), &mut self.trigger_right.button);
-        buttons.insert("left_analog".to_string(), &mut self.left_analog.button);
-        buttons.insert("right_analog".to_string(), &mut self.right_analog.button);
-
-        buttons
+    pub fn get_all_buttons(&mut self) -> HashMap<gilrs::Button, &mut ControllerButton> {
+        HashMap::from([
+            (gilrs::Button::DPadUp, &mut self.dpad_up),
+            (gilrs::Button::DPadDown, &mut self.dpad_down),
+            (gilrs::Button::DPadLeft, &mut self.dpad_left),
+            (gilrs::Button::DPadRight, &mut self.dpad_right),
+            (gilrs::Button::Start, &mut self.start),
+            (gilrs::Button::Select, &mut self.back),
+            (gilrs::Button::North, &mut self.y),
+            (gilrs::Button::South, &mut self.a),
+            (gilrs::Button::East, &mut self.b),
+            (gilrs::Button::West, &mut self.x),
+            (gilrs::Button::LeftTrigger, &mut self.bumper_left),
+            (gilrs::Button::LeftTrigger2, &mut self.trigger_left.button),
+            (gilrs::Button::RightTrigger, &mut self.bumper_right),
+            (gilrs::Button::RightTrigger2, &mut self.trigger_right.button),
+            (gilrs::Button::LeftThumb, &mut self.left_analog.button),
+            (gilrs::Button::RightThumb, &mut self.right_analog.button),])
     }
 
     pub fn get_left_analog_stick(&self) -> AnalogStick {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,7 +3,7 @@ use std::{collections::{HashMap, HashSet}, process::exit};
 use config::{Config, ConfigError};
 use native_dialog::DialogBuilder;
 use serde::Deserialize;
-use crate::controller::input::ControllerTypeDetection;
+use crate::controller::{action_manager::ActionDistance, input::ControllerTypeDetection};
 
 #[derive(Clone, Deserialize)]
 pub struct OverlaySettings {
@@ -50,26 +50,170 @@ impl ControllerSettings {
     pub fn controller_type(&self) -> ControllerTypeDetection {self.controller_type.clone()}
 }
 
+#[derive(Clone, Deserialize, Eq, Hash, PartialEq)]
+pub enum ButtonOrKey {
+    Button(rdev::Button),
+    Key(rdev::Key),
+    ButtonKeyCombo(rdev::Button, rdev::Key),
+    Empty,
+}
+
+fn string_to_buttonorkey (buttonorkey_string: &str) -> ButtonOrKey {
+    let lower = buttonorkey_string.to_lowercase();
+
+    // TODO(Samantha): Pattern matching here would be cleaner, but I don't think it's worth pulling in regex?
+    // These if guards check to see if we should be making a buttonkeychord.
+    if lower.ends_with("leftclick") && lower.len() > "leftclick".len() {
+        if let ButtonOrKey::Key(k) = string_to_buttonorkey(lower.trim_end_matches("leftclick")) {
+            return ButtonOrKey::ButtonKeyCombo(rdev::Button::Left, k);
+        }
+    }
+    if lower.ends_with("rightclick") && lower.len() > "rightclick".len(){
+        if let ButtonOrKey::Key(k) = string_to_buttonorkey(lower.trim_end_matches("rightclick")) {
+            return ButtonOrKey::ButtonKeyCombo(rdev::Button::Right, k);
+        }
+    }
+    if lower.ends_with("middleclick") && lower.len() > "middleclick".len(){
+        if let ButtonOrKey::Key(k) = string_to_buttonorkey(lower.trim_end_matches("middleclick")) {
+            return ButtonOrKey::ButtonKeyCombo(rdev::Button::Middle, k);
+        }
+    }
+
+    match lower.as_str() {
+        "leftclick" => ButtonOrKey::Button(rdev::Button::Left),
+        "middleclick" => ButtonOrKey::Button(rdev::Button::Middle),
+        "rightclick" => ButtonOrKey::Button(rdev::Button::Right),
+        "f1" => ButtonOrKey::Key(rdev::Key::F1),
+        "f2" => ButtonOrKey::Key(rdev::Key::F2),
+        "f3" => ButtonOrKey::Key(rdev::Key::F3),
+        "f4" => ButtonOrKey::Key(rdev::Key::F4),
+        "f5" => ButtonOrKey::Key(rdev::Key::F5),
+        "f6" => ButtonOrKey::Key(rdev::Key::F6),
+        "f7" => ButtonOrKey::Key(rdev::Key::F7),
+        "f8" => ButtonOrKey::Key(rdev::Key::F8),
+        "f9" => ButtonOrKey::Key(rdev::Key::F9),
+        "f10" => ButtonOrKey::Key(rdev::Key::F10),
+        "f11" => ButtonOrKey::Key(rdev::Key::F11),
+        "f12" => ButtonOrKey::Key(rdev::Key::F12),
+        "a" => ButtonOrKey::Key(rdev::Key::KeyA),
+        "b" => ButtonOrKey::Key(rdev::Key::KeyB),
+        "c" => ButtonOrKey::Key(rdev::Key::KeyC),
+        "d" => ButtonOrKey::Key(rdev::Key::KeyD),
+        "e" => ButtonOrKey::Key(rdev::Key::KeyE),
+        "f" => ButtonOrKey::Key(rdev::Key::KeyF),
+        "g" => ButtonOrKey::Key(rdev::Key::KeyG),
+        "h" => ButtonOrKey::Key(rdev::Key::KeyH),
+        "i" => ButtonOrKey::Key(rdev::Key::KeyI),
+        "j" => ButtonOrKey::Key(rdev::Key::KeyJ),
+        "k" => ButtonOrKey::Key(rdev::Key::KeyK),
+        "l" => ButtonOrKey::Key(rdev::Key::KeyL),
+        "m" => ButtonOrKey::Key(rdev::Key::KeyM),
+        "n" => ButtonOrKey::Key(rdev::Key::KeyN),
+        "o" => ButtonOrKey::Key(rdev::Key::KeyO),
+        "p" => ButtonOrKey::Key(rdev::Key::KeyP),
+        "q" => ButtonOrKey::Key(rdev::Key::KeyQ),
+        "r" => ButtonOrKey::Key(rdev::Key::KeyR),
+        "s" => ButtonOrKey::Key(rdev::Key::KeyS),
+        "t" => ButtonOrKey::Key(rdev::Key::KeyT),
+        "u" => ButtonOrKey::Key(rdev::Key::KeyU),
+        "v" => ButtonOrKey::Key(rdev::Key::KeyV),
+        "w" => ButtonOrKey::Key(rdev::Key::KeyW),
+        "x" => ButtonOrKey::Key(rdev::Key::KeyX),
+        "y" => ButtonOrKey::Key(rdev::Key::KeyY),
+        "z" => ButtonOrKey::Key(rdev::Key::KeyZ),
+        "0" => ButtonOrKey::Key(rdev::Key::Num0),
+        "1" => ButtonOrKey::Key(rdev::Key::Num1),
+        "2" => ButtonOrKey::Key(rdev::Key::Num2),
+        "3" => ButtonOrKey::Key(rdev::Key::Num3),
+        "4" => ButtonOrKey::Key(rdev::Key::Num4),
+        "5" => ButtonOrKey::Key(rdev::Key::Num5),
+        "6" => ButtonOrKey::Key(rdev::Key::Num6),
+        "7" => ButtonOrKey::Key(rdev::Key::Num7),
+        "8" => ButtonOrKey::Key(rdev::Key::Num8),
+        "9" => ButtonOrKey::Key(rdev::Key::Num9),
+        "`" => ButtonOrKey::Key(rdev::Key::BackQuote),
+        "[" => ButtonOrKey::Key(rdev::Key::LeftBracket),
+        "]" => ButtonOrKey::Key(rdev::Key::RightBracket),
+        ";" => ButtonOrKey::Key(rdev::Key::SemiColon),
+        "/" => ButtonOrKey::Key(rdev::Key::Slash),
+        "," => ButtonOrKey::Key(rdev::Key::Comma),
+        "=" => ButtonOrKey::Key(rdev::Key::Equal),
+        "escape" => ButtonOrKey::Key(rdev::Key::Escape),
+        "space" => ButtonOrKey::Key(rdev::Key::Space),
+        "tab" => ButtonOrKey::Key(rdev::Key::Tab),
+        "backspace" => ButtonOrKey::Key(rdev::Key::Backspace),
+        "delete" => ButtonOrKey::Key(rdev::Key::Delete),
+        "uparrow" => ButtonOrKey::Key(rdev::Key::UpArrow),
+        "downarrow" => ButtonOrKey::Key(rdev::Key::DownArrow),
+        "leftarrow" => ButtonOrKey::Key(rdev::Key::LeftArrow),
+        "rightarrow" => ButtonOrKey::Key(rdev::Key::RightArrow),
+        "alt" => ButtonOrKey::Key(rdev::Key::Alt),
+        "shift" => ButtonOrKey::Key(rdev::Key::ShiftLeft),
+        "control" => ButtonOrKey::Key(rdev::Key::ControlLeft),
+        "" => ButtonOrKey::Empty,
+        _ => {
+            alert_and_exit_on_invalid_settings(&format!("Unrecognized mouse button or key: {:}!", buttonorkey_string.to_lowercase().as_str()));
+            panic!("Unrecognized mouse button or key: {:}!", buttonorkey_string.to_lowercase().as_str());
+        },
+    }
+}
+
 #[derive(Clone, Deserialize)]
 pub struct ApplicationSettings {
     #[serde(rename(deserialize = "overlay"))]
     overlay_settings: OverlaySettings,
+
     #[serde(rename(deserialize = "button_mapping"))]
-    button_mapping_settings: HashMap<String, String>,
+    button_mapping_settings_strings: HashMap<String, String>,
     #[serde(skip_deserializing)]
-    ability_mapping_settings: HashMap<String, String>,
-    aimable_buttons: Vec<String>,
-    action_distances: HashMap<String, String>,
+    button_mapping_settings: HashMap<gilrs::Button, ButtonOrKey>,
+
+    #[serde(skip_deserializing)]
+    ability_mapping_settings: HashMap<ButtonOrKey, gilrs::Button>,
+
+    #[serde(rename(deserialize = "aimable_buttons"))]
+    aimable_buttons_strings: Vec<String>,
+    #[serde(skip_deserializing)]
+    aimable_buttons: HashSet<gilrs::Button>,
+
+    #[serde(rename(deserialize = "action_distances"))]
+    action_distances_strings: HashMap<String, ActionDistance>,
+    #[serde(skip_deserializing)]
+    action_distances: HashMap<gilrs::Button, ActionDistance>,
+
     #[serde(rename(deserialize = "controller"))]
     controller_settings: ControllerSettings,
 }
 
+fn string_to_controller_button(button_str: &str) -> gilrs::Button {
+    match button_str.to_lowercase().as_str() {
+        // We attempt to allow for different names of buttons.
+        "a" | "cross" | "face_down" => gilrs::Button::South,
+        "b" | "circle" | "face_right" => gilrs::Button::East,
+        "x" | "square" | "face_left" => gilrs::Button::West,
+        "y" | "triangle" | "face_up" => gilrs::Button::North,
+        "start" | "options" => gilrs::Button::Start,
+        "back" | "select" | "share" => gilrs::Button::Select,
+        "dpad_down" => gilrs::Button::DPadDown,
+        "dpad_left" => gilrs::Button::DPadLeft,
+        "dpad_right" => gilrs::Button::DPadRight,
+        "dpad_up" => gilrs::Button::DPadUp,
+        "left_analog" | "l3" => gilrs::Button::LeftThumb,
+        "right_analog" | "r3" => gilrs::Button::RightThumb,
+        "bumper_left" | "l1" => gilrs::Button::LeftTrigger,
+        "bumper_right" | "r1" => gilrs::Button::RightTrigger,
+        "trigger_left" | "l2" => gilrs::Button::LeftTrigger2,
+        "trigger_right" | "r2" => gilrs::Button::RightTrigger2,
+        _ => gilrs::Button::Unknown,
+    }
+}
+
 impl ApplicationSettings {
     pub fn overlay_settings(&self) -> OverlaySettings {self.overlay_settings.clone()}
-    pub fn button_mapping_settings(&self) -> HashMap<String, String> {self.button_mapping_settings.clone()}
-    pub fn ability_mapping_settings(&self) -> HashMap<String, String> {self.ability_mapping_settings.clone()}
-    pub fn aimable_buttons(&self) -> Vec<String> {self.aimable_buttons.clone()}
-    pub fn action_distances(&self) -> HashMap<String, String> {self.action_distances.clone()}
+    pub fn button_mapping_settings(&self) -> HashMap<gilrs::Button, ButtonOrKey> {self.button_mapping_settings.clone()}
+    pub fn ability_mapping_settings(&self) -> HashMap<ButtonOrKey, gilrs::Button> {self.ability_mapping_settings.clone()}
+    pub fn aimable_buttons(&self) -> HashSet<gilrs::Button> {self.aimable_buttons.clone()}
+    pub fn action_distances(&self) -> HashMap<gilrs::Button, ActionDistance> {self.action_distances.clone()}
     pub fn controller_settings(&self) -> ControllerSettings {self.controller_settings.clone()}
 
     fn sanitize_settings(&mut self) {
@@ -78,95 +222,102 @@ impl ApplicationSettings {
             panic!("Windowed Mode is unsupported when coupled with Always Show Overlay!");
         }
 
-        let valid_ability_buttons: HashSet<String> = HashSet::from(["face_up", "face_down", "face_left", "face_right", "bumper_left", "bumper_right", "trigger_left", "trigger_right"].map(|x| x.to_owned()));
-        let valid_ability_ranges: HashSet<String>= HashSet::from(["close", "mid", "far"].map(|x| x.to_owned()));
-        let buttons: Vec<String> = self.action_distances.keys().cloned().collect();
-        let distances: Vec<String> = self.action_distances.values().cloned().collect();
+        let valid_buttons_set = HashSet::from([
+            gilrs::Button::West,
+            gilrs::Button::North,
+            gilrs::Button::South,
+            gilrs::Button::East,
+            gilrs::Button::Start,
+            gilrs::Button::Select,
+            gilrs::Button::DPadDown,
+            gilrs::Button::DPadLeft,
+            gilrs::Button::DPadRight,
+            gilrs::Button::DPadUp,
+            gilrs::Button::LeftThumb,
+            gilrs::Button::RightThumb,
+            gilrs::Button::LeftTrigger,
+            gilrs::Button::RightTrigger,
+            gilrs::Button::LeftTrigger2,
+            gilrs::Button::RightTrigger2,]);
+
+        let valid_ability_buttons_set : HashSet<gilrs::Button> = HashSet::from([
+            gilrs::Button::South,
+            gilrs::Button::East,
+            gilrs::Button::West,
+            gilrs::Button::North,
+            gilrs::Button::LeftTrigger,
+            gilrs::Button::RightTrigger,
+            gilrs::Button::LeftTrigger2,
+            gilrs::Button::RightTrigger2,]);
+
+        let valid_aimable_buttons_set = HashSet::from([
+            gilrs::Button::West,
+            gilrs::Button::North,
+            gilrs::Button::South,
+            gilrs::Button::East,
+            gilrs::Button::LeftTrigger,
+            gilrs::Button::RightTrigger,
+            gilrs::Button::LeftTrigger2,
+            gilrs::Button::RightTrigger2,]);
+
+       // Finish deserializing these from strings into their concrete types.
+        self.action_distances = HashMap::from_iter(
+            self.action_distances_strings.iter()
+            .map(|(button_string, distance)|
+                 (string_to_controller_button(button_string), *distance)));
+
+        self.button_mapping_settings = HashMap::from_iter(
+            self.button_mapping_settings_strings.iter()
+            .map(|(key, value)|
+                 (string_to_controller_button(key), string_to_buttonorkey(value))));
+
+        self.aimable_buttons = self.aimable_buttons_strings.iter()
+            .map(|button| string_to_controller_button(button)).collect();
 
         // Ensure ability ranges!
-        for button in &buttons {
-            if !valid_ability_buttons.contains(button) {
-                alert_and_exit_on_invalid_settings(&format!("{:} is not a valid button ({:#?})", button, valid_ability_buttons));
-                panic!("{:} is not a valid button ({:#?})", button, valid_ability_buttons);
-            }
-        }
-        for distance in &distances {
-            if !valid_ability_ranges.contains(distance) {
-                alert_and_exit_on_invalid_settings(&format!("{:} is not a valid distance ({:#?})", distance, valid_ability_ranges));
-                panic!("{:} is not a valid distance ({:#?})", distance, valid_ability_ranges);
-            }
-        }
+        panic_on_extra_keys(&HashSet::from_iter(self.action_distances.keys().cloned()),
+                            &valid_ability_buttons_set,
+                            "action_distances");
 
         // Ensure buttons are valid!
-        let valid_buttons_set = HashSet::from(
-            [
-                "face_up",
-                "face_down",
-                "face_left",
-                "face_right",
-                "start",
-                "back",
-                "dpad_up",
-                "dpad_down",
-                "dpad_left",
-                "dpad_right",
-                "left_analog",
-                "right_analog",
-                "bumper_left",
-                "bumper_right",
-                "trigger_left",
-                "trigger_right"].map(|x| x.to_owned()));
-        let button_mapping_keys: Vec<String> = self.button_mapping_settings.keys().cloned().collect();
-        let button_mapping_key_set: HashSet<String >= HashSet::from_iter(button_mapping_keys);
-        if !ensure_initialized(&button_mapping_key_set, &valid_buttons_set) {
-            incorrect_keys(&button_mapping_key_set, &valid_buttons_set)
-        }
+        let button_mapping_keys = self.button_mapping_settings.keys().cloned();
+        let button_mapping_key_set: HashSet<gilrs::Button> = HashSet::from_iter(button_mapping_keys);
+        panic_on_missing_or_extra_keys(&button_mapping_key_set,
+                                       &valid_buttons_set,
+                                       "button_mapping");
 
         // Ensure aimables
-        let valid_aimable_buttons_set = HashSet::from(
-            [
-                "face_up",
-                "face_down",
-                "face_left",
-                "face_right",
-                "bumper_left",
-                "bumper_right",
-                "trigger_left",
-                "trigger_right"].map(|x| x.to_owned()));
-
-        for button in &self.aimable_buttons {
-            if !valid_aimable_buttons_set.contains(button) {
-                alert_and_exit_on_invalid_settings(&format!("{:} is not a valid aimable button ({:#?})", button, valid_aimable_buttons_set));
-                panic!("{:} is not a valid aimable button ({:#?})", button, valid_aimable_buttons_set);
-            }
-        }
+        panic_on_extra_keys(&self.aimable_buttons,
+                            &valid_aimable_buttons_set,
+                            "aimable_buttons");
 
         // Setup ability_mapping_settings
-        self.ability_mapping_settings.insert(self.button_mapping_settings.get("face_up").unwrap().clone(), "face_up".to_owned());
-        self.ability_mapping_settings.insert(self.button_mapping_settings.get("face_down").unwrap().clone(), "face_down".to_owned());
-        self.ability_mapping_settings.insert(self.button_mapping_settings.get("face_right").unwrap().clone(), "face_right".to_owned());
-        self.ability_mapping_settings.insert(self.button_mapping_settings.get("face_left").unwrap().clone(), "face_left".to_owned());
-        self.ability_mapping_settings.insert(self.button_mapping_settings.get("bumper_left").unwrap().clone(), "bumper_left".to_owned());
-        self.ability_mapping_settings.insert(self.button_mapping_settings.get("bumper_right").unwrap().clone(), "bumper_right".to_owned());
-        self.ability_mapping_settings.insert(self.button_mapping_settings.get("trigger_left").unwrap().clone(), "trigger_left".to_owned());
-        self.ability_mapping_settings.insert(self.button_mapping_settings.get("trigger_right").unwrap().clone(), "trigger_right".to_owned());
+        for button in valid_ability_buttons_set {
+            self.ability_mapping_settings.insert(
+                self.button_mapping_settings.get(&button).unwrap().clone(), button);
+        }
     }
 }
 
-fn ensure_initialized(test: &HashSet<String>, control: &HashSet<String>) -> bool {
-    test.is_subset(&control) && control.is_subset(&test)
-}
-
-fn incorrect_keys(test: &HashSet<String>, control: &HashSet<String>) {
-    let missing: Vec<&String> = control.difference(&test).collect();
+fn panic_on_missing_keys(test: &HashSet<gilrs::Button>, control: &HashSet<gilrs::Button>, field_name: &str) {
+    let missing: Vec<&gilrs::Button> = control.difference(&test).collect();
     if missing.len() > 0 {
-        alert_and_exit_on_invalid_settings(&format!("Must initialize button_mapping! You are missing {:#?}", missing));
+        alert_and_exit_on_invalid_settings(&format!("Must initialize {}! You are missing {:#?}", field_name, missing));
         panic!("Must initialize button_mapping! You are missing {:#?}", missing);
-    } else {
-        let extra: Vec<&String> = test.difference(&control).collect();
-        alert_and_exit_on_invalid_settings(&format!("Only initialize proper buttons: {:#?}! \n Your extras are: {:#?}", extra, control));
-        panic!("Only initialize proper buttons: {:#?}! \n Your extras are: {:#?}", extra, control);
     }
+}
+
+fn panic_on_extra_keys(test: &HashSet<gilrs::Button>, control: &HashSet<gilrs::Button>, field_name: &str) {
+    let extra: Vec<&gilrs::Button> = test.difference(&control).collect();
+    if extra.len() > 0 {
+        alert_and_exit_on_invalid_settings(&format!("Only initialize proper buttons for {}: {:#?}! \n Your extras are: {:#?}", field_name, control, extra));
+        panic!("Only initialize proper buttons for {}: {:#?}! \n Your extras are: {:#?}", field_name, control, extra);
+    }
+}
+
+fn panic_on_missing_or_extra_keys(test: &HashSet<gilrs::Button>, control: &HashSet<gilrs::Button>, field_name: &str) {
+    panic_on_missing_keys(&test, &control, field_name);
+    panic_on_extra_keys(&test, &control, field_name);
 }
 
 


### PR DESCRIPTION
This should make the main controller loop more performant and less brittle.

This does _not_ attempt to automatically deserialize controller buttons or mouse/keyboard buttons into their concrete types, that still happens in settings.