### PR TITLE
Allows for controllers to be selected from a dropdown.

### DIFF
--- a/src/controller/input.rs
+++ b/src/controller/input.rs
@@ -197,12 +197,6 @@ pub fn load_gamepad_manager(analog_deadzone: f32) -> GamepadManager {
         controller_state: ControllerState::default(),
     };
 
-    // Gilrs will not initially throw a connected event if a controller is connected from the start
-    let connected_controllers = gamepad_manager.get_connected_controllers();
-    if !connected_controllers.is_empty() {
-        gamepad_manager.connect_to_controller(connected_controllers, 0);
-    }
-
     // initialize triggers and joy stick deadzones
     let gamepad_triggers_threshold = 0.8_f32;
     gamepad_manager.controller_state.trigger_left.set_trigger_threshold(gamepad_triggers_threshold);
@@ -260,11 +254,7 @@ impl GamepadManager {
                 // gilrs doesn't register new gamepads in gilrs_context.gamepads() until EventType::Connected events have been pulled off the events queue.
                 None => {
                     match event {
-                        EventType::Connected => {
-                            // TODO(Samantha): Is this really what we want to do here? Reconsider when we allow changing controllers.
-                            let connected_controllers = self.get_connected_controllers();
-                            self.connect_to_controller(connected_controllers, 0)
-                        },
+                        EventType::Connected => (),
                         _ => (),
                     }
                 },
@@ -272,7 +262,7 @@ impl GamepadManager {
         }
     }
 
-    pub fn get_connected_controllers(&mut self) -> Vec<(GamepadId, String)> { 
+    pub fn get_connected_controllers(&self) -> Vec<(GamepadId, String)> {
         let mut connected_controllers = Vec::<(GamepadId, String)>::new();
         for (gamepad_id, gamepad) in self.gilrs_context.gamepads() {
             connected_controllers.push((gamepad_id, gamepad.name().to_string()));
@@ -281,24 +271,19 @@ impl GamepadManager {
     }
 
     pub fn is_controller_connected(&self) -> bool {
-        match self.gamepad_id {
-            Some(_c) => true,
-            None => false,
-        }
+        self.get_connected_controllers().len() > 0
     }
 
     pub fn connect_to_controller(&mut self, connected_controllers: Vec<(GamepadId, String)>, index: usize) { 
         let gamepad_id = connected_controllers[index].0;
         self.gamepad_id = Some(gamepad_id);
         self.controller_type = Some(self.infer_controller_type());
-        println!("Controller connected!");
     }
 
     pub fn get_connected_controller_label(&self) -> String {
-        if self.is_controller_connected() {
-            self.gilrs_context.gamepad(self.gamepad_id.unwrap()).os_name().to_owned()
-        } else {
-            "none".to_owned()
+        match self.gamepad_id {
+            Some(id) => self.gilrs_context.gamepad(id).os_name().to_owned(),
+            None => "none".to_owned(),
         }
     }
 

--- a/src/overlay/game_overlay.rs
+++ b/src/overlay/game_overlay.rs
@@ -177,13 +177,16 @@ impl GameOverlay {
                                         egui::Grid::new("Remote Grid ID").min_col_width(220.0).show(ui, |ui| {
                                             let mut can_overlay_start = true;
                                             if self.gamepad_manager.is_controller_connected() {
-                                                let controller_label =  self.gamepad_manager.get_connected_controller_label();
-                                                ui.label(String::from("Controller connected: ") + controller_label.as_str());
+                                                // let controller_label =  self.gamepad_manager.get_connected_controller_label();
+                                                // ui.label(String::from("Controller connected: ") + controller_label.as_str());
                                                 let connected_controllers = self.gamepad_manager.get_connected_controllers();
-                                                egui::ComboBox::from_label("Select Connected Controller:")
-                                                .selected_text(format!("{:?}", &mut self.selected_controller_dropdown_index))
-                                                .show_index(ui, &mut self.selected_controller_dropdown_index, connected_controllers.len(), |i| connected_controllers[i].1.to_owned());
+                                                ui.label(egui::RichText::new("Select from connected controllers:").size(14.0));
+                                                ui.end_row();
+                                                egui::ComboBox::from_id_salt("controller-select-dropdown")
+                                                                .selected_text(format!("{:?}", &mut self.selected_controller_dropdown_index))
+                                                                .show_index(ui, &mut self.selected_controller_dropdown_index, connected_controllers.len(), |i| connected_controllers[i].1.to_owned());
                                                 self.gamepad_manager.connect_to_controller(connected_controllers, self.selected_controller_dropdown_index);
+                                                ui.end_row();
                                             } else {
                                                 ui.label(String::from("No controller connected."));
                                                 can_overlay_start = false;

--- a/src/overlay/game_overlay.rs
+++ b/src/overlay/game_overlay.rs
@@ -33,6 +33,7 @@ struct GameOverlay {
     remote_open: bool,
     remote_pos: Pos2,
     game_input_started: bool,
+    selected_controller_dropdown_index: usize,
 }
 
 impl GameOverlay {
@@ -178,14 +179,11 @@ impl GameOverlay {
                                             if self.gamepad_manager.is_controller_connected() {
                                                 let controller_label =  self.gamepad_manager.get_connected_controller_label();
                                                 ui.label(String::from("Controller connected: ") + controller_label.as_str());
-                                            //     let mut selected = 0 as usize;
-                                            //     egui::ComboBox::from_label("Select Connected Controller:")
-                                            //     .selected_text(format!("{:?}", selected))
-                                            //     .show_index(ui, &mut selected, connected_controllers.len(), |i| connected_controllers[i].1.to_owned());
-                                            //     self.gamepad_manager.select_connected_controller(connected_controllers.get(selected).unwrap().0);
-                                            // } else {
-                                            //     let mut selected = 0 as usize;
-                                            //     egui::ComboBox::from_label("Connect a controller").selected_text("None connected").show_index(ui, &mut selected, 1, |_i| "".to_string());
+                                                let connected_controllers = self.gamepad_manager.get_connected_controllers();
+                                                egui::ComboBox::from_label("Select Connected Controller:")
+                                                .selected_text(format!("{:?}", &mut self.selected_controller_dropdown_index))
+                                                .show_index(ui, &mut self.selected_controller_dropdown_index, connected_controllers.len(), |i| connected_controllers[i].1.to_owned());
+                                                self.gamepad_manager.connect_to_controller(connected_controllers, self.selected_controller_dropdown_index);
                                             } else {
                                                 ui.label(String::from("No controller connected."));
                                                 can_overlay_start = false;
@@ -315,6 +313,7 @@ pub fn start_overlay(overlay_settings: OverlaySettings,
         remote_open: true,
         remote_pos: Pos2 { x: screen_width / 2.0 , y: screen_height / 16.0 },
         game_input_started: false,
+        selected_controller_dropdown_index: 0,
     };
     
     overlay_backend::start(game_overlay);


### PR DESCRIPTION
From some quick testing, this seems to "just work" :tm:. This does change the meaning of a function, `GamepadManager::is_controller_connected` to mean if there are controllers connected to the system, not one selected.

Additionally, while this has no consequences in the current implementation, this does not ~~connect to~~ select a controller by default on inititialization.

Closes #1 